### PR TITLE
Rewrite raw product slicing

### DIFF
--- a/procsim/biomass/level0_product_generator.py
+++ b/procsim/biomass/level0_product_generator.py
@@ -166,7 +166,7 @@ class Sx_RAW__0x(product_generator.ProductGeneratorBase):
             start,
             stop
         )
-            
+
         # Determine and set the slice number if not set already.
         if self._hdr.acquisitions[0].slice_frame_nr is None:
             # Get slice number from middle of slice to deal with merged slices.
@@ -413,7 +413,7 @@ class AC_RAW__0A(product_generator.ProductGeneratorBase):
         self._hdr.incomplete_l0_slice = False
         self._hdr.partial_l0_slice = False
         self._hdr.acquisitions[0].slice_frame_nr = None
-        
+
         name_gen = self._create_name_generator(self._hdr)
         dir_name = name_gen.generate_path_name()
         self._hdr.initialize_product_list(dir_name)

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -20,6 +20,7 @@ from . import main_product_header, product_name
 
 class GeneratedFile():
     '''Hold some information on a file that is to be generated.'''
+
     def __init__(self, path: List[str] = [], suffix: str = '', extension: str = '', representation: Optional['GeneratedFile'] = None) -> None:
         self.path: List[str] = path
         self.suffix: str = suffix
@@ -245,7 +246,7 @@ class ProductGeneratorBase(IProductGenerator):
             self._logger.error('Cannot find matching product for [{}] to extract metdata from'.format(pattern))
             return False
         return True
-    
+
     def _parse_orbit_prediction_file(self, file_name: str) -> List[datetime.datetime]:
         '''Get ANX timestamp information from orbit prediction file.'''
         root = et.parse(file_name).getroot()
@@ -257,7 +258,7 @@ class ProductGeneratorBase(IProductGenerator):
                 # Trim 'UTC=' off the start of the timestamp and convert to datetime.
                 self._anx_list.append(datetime.datetime.fromisoformat(utc_timestamp.text[4:]))
         self._anx_list.sort()
-        
+
         return self._anx_list
 
     def _get_anx(self, t: datetime.datetime) -> Optional[datetime.datetime]:
@@ -270,7 +271,7 @@ class ProductGeneratorBase(IProductGenerator):
         sigma = datetime.timedelta(0, 1.0)   # Just a small time delta (wrt to the slice duration)
         idx = bisect.bisect(self._anx_list, t + sigma) - 1
         return self._anx_list[min(max(idx, 0), len(self._anx_list) - 1)]
-    
+
     def _get_slice_frame_nr(self, start: datetime.datetime, spacing: datetime.timedelta) -> Optional[int]:
         sigma = datetime.timedelta(0, 1.0)   # Just a small time delta (wrt to the slice duration)
         previous_anx = self._get_anx(start)


### PR DESCRIPTION
The previous implementation of product slicing was somewhat monolithic and challenging to understand/alter. The proposed changes offer a more segmented implementation, where the slicing is done first and the relevant times around these slices determined and set later.