### PR TITLE
Set validity time from slice bounds (Issue 15)

### DIFF
--- a/procsim/biomass/level0_product_generator.py
+++ b/procsim/biomass/level0_product_generator.py
@@ -390,6 +390,10 @@ class AC_RAW__0A(product_generator.ProductGeneratorBase):
         if self._hdr.begin_position is None or self._hdr.end_position is None:
             raise ScenarioError('Begin/end position must be set')
 
+        # Adjust start/stop times, add margins
+        self._hdr.begin_position -= datetime.timedelta(0, self._leading_margin)
+        self._hdr.end_position += datetime.timedelta(0, self._trailing_margin)
+
         # If not read from an input product, use begin/end position as starting point
         if self._hdr.validity_start is None:
             self._hdr.validity_start = self._hdr.begin_position
@@ -397,12 +401,6 @@ class AC_RAW__0A(product_generator.ProductGeneratorBase):
         if self._hdr.validity_stop is None:
             self._hdr.validity_stop = self._hdr.end_position
             self._logger.debug('Use end_position as input for validity stop time')
-
-        # Adjust start/stop times, add margins
-        self._hdr.begin_position -= datetime.timedelta(0, self._leading_margin)
-        self._hdr.end_position += datetime.timedelta(0, self._trailing_margin)
-        self._hdr.validity_start = self._hdr.begin_position
-        self._hdr.validity_stop = self._hdr.end_position
 
         # Setup other MPH fields
         self._hdr.product_type = self._output_type

--- a/procsim/biomass/level0_product_generator.py
+++ b/procsim/biomass/level0_product_generator.py
@@ -211,14 +211,14 @@ class Sx_RAW__0x(product_generator.ProductGeneratorBase):
         slice_bounds = self._get_slice_frame_interval(middle_position, constants.SLICE_GRID_SPACING)
         if self._hdr.validity_start is None:
             if slice_bounds is None:
-                self._logger.warning(f'Could not find slice bounds for central position {middle_position}. Using {self._hdr.begin_position} as validity start.')
+                self._logger.warning(f'Could not find slice bounds. Using {self._hdr.begin_position} as validity start.')
                 self._hdr.validity_start = self._hdr.begin_position
             else:
                 self._logger.debug(f'Use slice start {slice_bounds[0]} as input for validity start time')
                 self._hdr.validity_start = slice_bounds[0] - constants.SLICE_OVERLAP_START
         if self._hdr.validity_stop is None:
             if slice_bounds is None:
-                self._logger.warning(f'Could not find slice bounds for central position {middle_position}. Using {self._hdr.end_position} as validity end.')
+                self._logger.warning(f'Could not find slice bounds. Using {self._hdr.end_position} as validity end.')
                 self._hdr.validity_stop = self._hdr.end_position
             else:
                 self._logger.debug(f'Use slice end {slice_bounds[1]} as input for validity stop time')

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -277,6 +277,16 @@ class ProductGeneratorBase(IProductGenerator):
         previous_anx = self._get_anx(start)
         return (start + sigma - previous_anx) // spacing if previous_anx is not None else None
 
+    def _get_slice_frame_interval(self, start: datetime.datetime, spacing: datetime.timedelta) -> Optional[Tuple[datetime.datetime, datetime.datetime]]:
+        previous_anx = self._get_anx(start)
+        if previous_anx is None:
+            return None
+        sigma = datetime.timedelta(0, 1.0)   # Just a small time delta (wrt to the slice duration)
+        slice_nr = (start + sigma - previous_anx) // spacing
+        slice_start = previous_anx + slice_nr * spacing
+        slice_end = previous_anx + (slice_nr + 1) * spacing
+        return slice_start, slice_end
+
     def _read_config_param(self, config: dict, param_name: str, obj: object, hdr_field: str, ptype):
         '''
         If param_name is in config, read and set in obj.field.


### PR DESCRIPTION
Previously, validity times were incorrectly set from data take times (issue #15) if they had not been explicitly specified by the user. The proposed changes set the validity time from the slice bounds instead, even if the data take does not fully cover it.