### PR TITLE
35 error while generating virtual frame product cpf l1vfra

### DIFF
--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -89,6 +89,17 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
     It outputs a Virtual Frame product for each L1 Frame contained in the L0S,
     each of them containing the framing parameters (mainly frame index and
     start-stop times) of a single frame.
+
+    The acquisition period (phenomenon begin/end times) of the metadata_source
+    (i.e. a L0 product) is framed. The frame grid is aligned to ANX.
+    An array "anx" with one or more ANX times can be specified in the scenario,
+    or a slice number can be supplied in the slice_frame_nr parameter.
+    For example:
+
+      "anx": [
+        "2021-02-01T00:25:33.745Z",
+        "2021-02-01T02:03:43.725Z"
+      ],
     '''
     PRODUCTS = ['CPF_L1VFRA']
 

--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -9,7 +9,7 @@ import os
 import xml.dom.minidom as md
 from enum import Enum
 from textwrap import dedent
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Optional, Tuple
 from xml.etree import ElementTree as et
 
 import re
@@ -191,29 +191,13 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
         acq_start, acq_end = self._hdr.begin_position, self._hdr.end_position
         slice_start, slice_end = self._hdr.validity_start, self._hdr.validity_stop
         slice_nr = self._hdr.acquisitions[0].slice_frame_nr
-        first_frame_nr = (slice_nr - 1) * NUM_FRAMES_PER_SLICE + 1 if slice_nr else None
 
         # Sanity checks
         if slice_start is None or slice_end is None or acq_start is None or acq_end is None:
-            raise ScenarioError('Start/stop times must be known here!')
-        if slice_nr is None or first_frame_nr is None:
-            raise ScenarioError('Cannot perform framing, slice nr. is not known')
+            raise ScenarioError('Start/stop times must be known here.')
 
-        # Align slice start and end with grid.
-        slice_start += self._slice_overlap_start
-        slice_end -= self._slice_overlap_end
-
-        # Check whether slice is incomplete. If so, the slice number/range is unreliable, so try to get them from ANX info.
-        delta = (slice_end - slice_start) - self._frame_grid_spacing * NUM_FRAMES_PER_SLICE
-        if delta < -datetime.timedelta(0, 0.01) or delta > datetime.timedelta(0, 0.01):
-            first_frame_nr = self._get_slice_frame_nr(acq_start, self._frame_grid_spacing)
-            slice_bounds = self._get_slice_frame_interval(acq_start, SLICE_GRID_SPACING)
-            if first_frame_nr is None or slice_bounds is None:
-                raise GeneratorError(dedent(f'\
-                    Cannot perform framing, slice length (without overlaps) != {NUM_FRAMES_PER_SLICE}x frame length \
-                    ({slice_end - slice_start} != {NUM_FRAMES_PER_SLICE}x{self._frame_grid_spacing}). \
-                    Additionally, the slice frame number could not be determined from the ANX information.'))
-            slice_start, slice_end = slice_bounds
+        slice_start, slice_end = self._align_slice_times(slice_start, slice_end)
+        first_frame_nr = self._get_first_frame_nr(slice_nr, acq_start)
 
         frames = self._generate_frames(slice_start, acq_start, acq_end, first_frame_nr)
 
@@ -226,6 +210,43 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
             self._frame_status = frame.status
 
             self._generate_product()
+
+    def _align_slice_times(self, start: datetime.datetime, stop: datetime.datetime) -> Tuple[datetime.datetime, datetime.datetime]:
+        '''
+        Given an alleged start and stop time of a slice, check whether they're
+        aligned. If not, attempt to align or recalculate them.
+        '''
+        sigma = datetime.timedelta(seconds=0.01)  # Be a little lenient in checking slice bounds.
+        # Check if already aligned.
+        delta = (stop - start) - SLICE_GRID_SPACING
+        if delta > -sigma and delta < sigma:
+            return (start, stop)
+
+        # Check if aligned when overlaps subtracted.
+        delta = ((stop - self._slice_overlap_end) - (start + self._slice_overlap_start)) - SLICE_GRID_SPACING
+        if delta > -sigma and delta < sigma:
+            return (start + self._slice_overlap_start, stop - self._slice_overlap_end)
+
+        # Could not align based on overlaps. Try to align based on ANX times.
+        slice_bounds = self._get_slice_frame_interval(start + (stop - start) / 2, SLICE_GRID_SPACING)
+        if slice_bounds is None:
+            raise ScenarioError(f'Could not determine exact slice bounds from start {start} and stop {stop}.')
+        return slice_bounds
+
+    def _get_first_frame_nr(self, slice_nr: Optional[int], start_time: datetime.datetime) -> int:
+        '''
+        If a slice number is provided, use that to determine the first frame
+        number. Else determine frame number from ANX times.
+        '''
+        if slice_nr is not None:
+            first_frame_nr = (slice_nr - 1) * NUM_FRAMES_PER_SLICE + 1
+        else:
+            first_frame_nr = self._get_slice_frame_nr(start_time, self._frame_grid_spacing)
+            if first_frame_nr is None:
+                raise ScenarioError(f'Cannot determine frame number from slice number {slice_nr} or start time {start_time} ' +
+                                    f'given ANX {self._anx_list}.')
+
+        return first_frame_nr
 
     def _generate_frames(self, slice_start: datetime.datetime,
                          acq_start: datetime.datetime, acq_end: datetime.datetime,

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -82,7 +82,11 @@ class ProductGeneratorBase(IProductGenerator):
         self._meta_data_source: Optional[str] = output_config.get('metadata_source')
         self._hdr = main_product_header.MainProductHeader()
         self._meta_data_source_file = None
+        # Get anx list from config. Can be located at either scenario or product level
         self._anx_list = []
+        scenario_anx_list = output_config.get('anx', []) or scenario_config.get('anx', [])
+        self._anx_list.extend([self._time_from_iso(anx) for anx in scenario_anx_list])
+        self._anx_list.sort()
 
         # Parameters that can be set in scenario
         self._output_path: str = '.' if job_config is None else job_config.dir

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -9,6 +9,7 @@ import re
 import shutil
 from typing import Iterable, List, Optional, Tuple
 from xml.etree import ElementTree as et
+from procsim.biomass.constants import ORBITAL_PERIOD
 
 from procsim.biomass.product_types import ORBPRE_PRODUCT_TYPES
 from procsim.core.exceptions import GeneratorError, ScenarioError
@@ -287,7 +288,11 @@ class ProductGeneratorBase(IProductGenerator):
 
     def _get_slice_frame_nr(self, start: datetime.datetime, spacing: datetime.timedelta) -> Optional[int]:
         previous_anx = self._get_anx(start)
-        return (start - previous_anx) // spacing + 1 if previous_anx is not None else None
+        if previous_anx is None:
+            return None
+        slice_frame_per_orbit = round(ORBITAL_PERIOD / spacing)
+        absolute_slice_frame_nr = (start - previous_anx) // spacing
+        return (absolute_slice_frame_nr % slice_frame_per_orbit) + 1
 
     def _get_slice_frame_interval(self,
                                   start: datetime.datetime,

--- a/procsim/biomass/raw_product_generator.py
+++ b/procsim/biomass/raw_product_generator.py
@@ -184,10 +184,6 @@ class RAWSxxx_10(RawProductGeneratorBase):
 
     def __init__(self, logger, job_config, scenario_config: dict, output_config: dict):
         super().__init__(logger, job_config, scenario_config, output_config)
-        # Get anx list from config. Can be located at either scenario or product level
-        scenario_anx_list = output_config.get('anx', []) or scenario_config.get('anx', [])
-        self._anx_list.extend([self._time_from_iso(anx) for anx in scenario_anx_list])
-        self._anx_list.sort()
         self._enable_slicing = True
         self._slice_grid_spacing = constants.SLICE_GRID_SPACING
         self._slice_overlap_start = constants.SLICE_OVERLAP_START

--- a/procsim/biomass/test/test_slice_frame_utlities.py
+++ b/procsim/biomass/test/test_slice_frame_utlities.py
@@ -64,7 +64,7 @@ class SliceFrameUtilitiesTest(unittest.TestCase):
 
         # Get slices/frame numbers within and after the second orbit.
         self.assertEqual(self.gen._get_slice_frame_nr(self.anx2, self.spacing), 1)
-        self.assertEqual(self.gen._get_slice_frame_nr(self.anx2 + self.spacing * 1000, self.spacing), 1001)
+        self.assertEqual(self.gen._get_slice_frame_nr(self.anx2 + self.spacing * 1000, self.spacing), 1)
 
     def test_get_slice_frame_interval(self) -> None:
         # Get an interval before the first ANX.
@@ -83,8 +83,7 @@ class SliceFrameUtilitiesTest(unittest.TestCase):
 
         # Get intervals within and after the second orbit.
         self.assertEqual(self.gen._get_slice_frame_interval(self.anx2, self.spacing), (self.anx2, self.anx2 + self.spacing))
-        self.assertEqual(self.gen._get_slice_frame_interval(self.anx2 + 1000.5 * self.spacing, self.spacing),
-                         (self.anx2 + 1000 * self.spacing, self.anx2 + 1001 * self.spacing))
+        self.assertEqual(self.gen._get_slice_frame_interval(self.anx2 + 1000.5 * self.spacing, self.spacing), (self.anx2, self.anx2 + self.spacing))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR concerns a situation (#35) in which it is attempted to generate virtual frames given ANX information instead of a slice number.