### PR TITLE
35 error while generating virtual frame product cpf l1vfra

### DIFF
--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -265,8 +265,19 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
         '''
         Generate a list of Frame objects between start and end times.
         '''
-        # Get frame boundaries between the slice validity start and end.
-        frame_bounds = [slice_start + d * self._frame_grid_spacing for d in range(NUM_FRAMES_PER_SLICE + 1)]
+        # Get frame boundaries between the slice sensing start and end.
+        frame_bounds = []
+        frame_bounds_start = slice_start  # + (acq_start - slice_start) // self._frame_grid_spacing * self._frame_grid_spacing
+        # Move to sensing start.
+        while frame_bounds_start <= acq_start:
+            frame_bounds_start += self._frame_grid_spacing
+        # Record frame bounds within sensing time.
+        while frame_bounds_start < acq_end:
+            frame_bounds.append(frame_bounds_start)
+            frame_bounds_start += self._frame_grid_spacing
+        # Make sure acquisition start and end are included.
+        frame_bounds.insert(0, acq_start)
+        frame_bounds.append(acq_end)
 
         # Map to frame instances.
         frames = []

--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -64,12 +64,9 @@ class FrameStatus(str, Enum):
 class Frame:
     '''This class is responsible for storing basic information about a frame's range and status.'''
     def __init__(self, id: int,
-                 validity_start: datetime.datetime, validity_stop: datetime.datetime,
                  sensing_start: datetime.datetime, sensing_stop: datetime.datetime,
                  status: str = ''):
         self.id = id
-        self.validity_start = validity_start
-        self.validity_stop = validity_stop
         self.sensing_start = sensing_start
         self.sensing_stop = sensing_stop
         self.status = status

--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -221,6 +221,8 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
         '''
         Given an alleged start and stop time of a slice, check whether they're
         aligned. If not, attempt to align or recalculate them.
+        This method returns the start and stop times of the slice, not including
+        begin/end overlaps.
         '''
         sigma = datetime.timedelta(seconds=0.01)  # Be a little lenient in checking slice bounds.
         # Check if already aligned.

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -131,19 +131,29 @@ class FrameGeneratorTest(unittest.TestCase):
     gen = Level1PreProcessor(_Logger(), None, STANDARD_CONFIG, STANDARD_CONFIG)
     gen.read_scenario_parameters()
 
-    '''Try to create frames from an entire slice including overlaps on either side.'''
     def test_entire_slice(self) -> None:
+        '''Try to create frames from an entire slice including overlaps on either side.'''
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START,
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
 
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE)
-        for fi, frame in enumerate(frames[:-1]):
-            self.assertEqual(frame.id, fi + 1)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
+        # Disregard the first and last frames here since they resulted from slice overlap data, and were merged with their neighbours.
+        for fi, frame in enumerate(frames[1:-1], start=1):
+            self.assertEqual(frame.id, fi + 2)  # Frame ID is 1-based and the first was merged with the second.
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
+        # Check first and last frames.
+        first_frame = frames[0]
+        self.assertEqual(first_frame.id, 2)  # Frame ID is 1-based and the first was merged with the second.
+        self.assertEqual(first_frame.sensing_start, ANX1 - constants.SLICE_OVERLAP_START)
+        self.assertEqual(first_frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
+        self.assertEqual(first_frame.status, 'MERGED')
+        last_frame = frames[-1]
+        self.assertEqual(last_frame.id, constants.NUM_FRAMES_PER_SLICE + 1)
+        self.assertEqual(last_frame.sensing_start, ANX1 + constants.SLICE_GRID_SPACING - constants.FRAME_GRID_SPACING)
+        self.assertEqual(last_frame.sensing_stop, ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END)
+        self.assertEqual(last_frame.status, 'MERGED')
 
     def test_slice_no_overlap(self) -> None:
         '''Try to create frames from a slice that does not include overlaps on either side.'''
@@ -152,16 +162,12 @@ class FrameGeneratorTest(unittest.TestCase):
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE)
         for fi, frame in enumerate(frames[:-1]):
             self.assertEqual(frame.id, fi + 1)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
 
         # The last frame should have a shorter sensing time since the overlap can't be applied.
         self.assertEqual(frames[-1].id, len(frames))
-        self.assertEqual(frames[-1].validity_start, ANX1 + constants.FRAME_GRID_SPACING * (len(frames) - 1))
-        self.assertEqual(frames[-1].validity_stop, ANX1 + constants.FRAME_GRID_SPACING * len(frames) + constants.FRAME_OVERLAP)
         self.assertEqual(frames[-1].sensing_start, ANX1 + constants.FRAME_GRID_SPACING * (len(frames) - 1))
         self.assertEqual(frames[-1].sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * len(frames))
         self.assertEqual(frames[-1].status, 'PARTIAL')
@@ -170,37 +176,33 @@ class FrameGeneratorTest(unittest.TestCase):
         '''Create frames from a slice that is missing data in its first frame range.'''
         # Choose offset just on the edge of the frame getting merged.
         test_offset = constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP - constants.FRAME_MINIMUM_DURATION
-        frames = self.gen._generate_frames(ANX1, ANX1 + test_offset, ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
+        frames = self.gen._generate_frames(ANX1, ANX1 + test_offset, ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
 
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE)
-        # The first frame should have a shorter sensing time since the overlap can't be applied.
-        self.assertEqual(frames[0].id, 1)
-        self.assertEqual(frames[0].validity_start, ANX1)
-        self.assertEqual(frames[0].validity_stop, ANX1 + constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
-        self.assertEqual(frames[0].sensing_start, ANX1 + test_offset)
-        self.assertEqual(frames[0].sensing_stop, ANX1 + constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
-        self.assertEqual(frames[0].status, 'PARTIAL')
+        # Test all but first and last frames.
         for fi, frame in enumerate(frames):
             if fi == 0:
                 continue
             self.assertEqual(frame.id, fi + 1)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
+        # The first frame should have a shorter sensing time since the overlap can't be applied.
+        first_frame = frames[0]
+        self.assertEqual(first_frame.id, 1)
+        self.assertEqual(first_frame.sensing_start, ANX1 + test_offset)
+        self.assertEqual(first_frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
+        self.assertEqual(first_frame.status, 'PARTIAL')
 
     def test_frame_merge(self) -> None:
         '''Make the first frame so short that it's merged into its neighbour.'''
         # Choose offset just over the edge of the frame getting merged.
         test_offset = constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP - constants.FRAME_MINIMUM_DURATION + datetime.timedelta(microseconds=1)
-        frames = self.gen._generate_frames(ANX1, ANX1 + test_offset, ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
+        frames = self.gen._generate_frames(ANX1, ANX1 + test_offset, ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
 
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE - 1)
         # The first frame should have a longer sensing time since it resulted from a merge.
         self.assertEqual(frames[0].id, 2)
-        self.assertEqual(frames[0].validity_start, ANX1 + constants.FRAME_GRID_SPACING)
-        self.assertEqual(frames[0].validity_stop, ANX1 + 2 * constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
         self.assertEqual(frames[0].sensing_start, ANX1 + test_offset)
         self.assertEqual(frames[0].sensing_stop, ANX1 + 2 * constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
         self.assertEqual(frames[0].status, 'MERGED')
@@ -208,8 +210,6 @@ class FrameGeneratorTest(unittest.TestCase):
             if fi == 0:
                 continue
             self.assertEqual(frame.id, fi + 2)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1))
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 2) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1))
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 2) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
@@ -218,14 +218,10 @@ class FrameGeneratorTest(unittest.TestCase):
         '''Shorten the slice so that the first or last frame goes missing entirely.'''
         # Remove first frame.
         frames = self.gen._generate_frames(ANX1, ANX1 + constants.FRAME_GRID_SPACING,
-                                           ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
+                                           ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE - 1)
         for fi, frame in enumerate(frames):
-            if fi == 0:
-                continue
-            self.assertEqual(frame.id, fi + 2)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1))
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 2) + constants.FRAME_OVERLAP)
+            self.assertEqual(frame.id, fi + 1)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1))
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 2) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
@@ -236,11 +232,21 @@ class FrameGeneratorTest(unittest.TestCase):
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE - 1)
         for fi, frame in enumerate(frames):
             self.assertEqual(frame.id, fi + 1)
-            self.assertEqual(frame.validity_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
-            self.assertEqual(frame.validity_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
+
+    def test_timerange_exceeds_slice_bounds(self) -> None:
+        '''
+        When the requested time range exceeds a slice boundary, frames should be
+        generated within either slice.
+        '''
+        sensing_start = ANX1
+        sensing_stop = ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_MINIMUM_DURATION + datetime.timedelta(seconds=1)
+        frames = self.gen._generate_frames(sensing_start, sensing_start, sensing_stop, 1)
+        self.assertEqual(frames[0].sensing_start, ANX1)
+        self.assertEqual(frames[-1].sensing_start, ANX1 + constants.SLICE_GRID_SPACING)
+        self.assertEqual(frames[-1].sensing_stop, sensing_stop)
 
 
 class VirtualFrameProductTest(unittest.TestCase):

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -137,20 +137,20 @@ class FrameGeneratorTest(unittest.TestCase):
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
 
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE)
-        # Disregard the first and last frames here since they resulted from slice overlap data, and were merged with their neighbours.
+        # Disregard the first and last frames here since they resulted from slice overlap data and were merged with their neighbours.
         for fi, frame in enumerate(frames[1:-1], start=1):
-            self.assertEqual(frame.id, fi + 2)  # Frame ID is 1-based and the first was merged with the second.
+            self.assertEqual(frame.id, fi + 1)  # The first frame was merged, but the count begins at the slice start.
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')
         # Check first and last frames.
         first_frame = frames[0]
-        self.assertEqual(first_frame.id, 2)  # Frame ID is 1-based and the first was merged with the second.
+        self.assertEqual(first_frame.id, 1)  # The first frame was merged, but the count begins at the slice start.
         self.assertEqual(first_frame.sensing_start, ANX1 - constants.SLICE_OVERLAP_START)
         self.assertEqual(first_frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING + constants.FRAME_OVERLAP)
         self.assertEqual(first_frame.status, 'MERGED')
         last_frame = frames[-1]
-        self.assertEqual(last_frame.id, constants.NUM_FRAMES_PER_SLICE + 1)
+        self.assertEqual(last_frame.id, constants.NUM_FRAMES_PER_SLICE)
         self.assertEqual(last_frame.sensing_start, ANX1 + constants.SLICE_GRID_SPACING - constants.FRAME_GRID_SPACING)
         self.assertEqual(last_frame.sensing_stop, ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END)
         self.assertEqual(last_frame.status, 'MERGED')
@@ -179,10 +179,8 @@ class FrameGeneratorTest(unittest.TestCase):
         frames = self.gen._generate_frames(ANX1, ANX1 + test_offset, ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
 
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE)
-        # Test all but first and last frames.
-        for fi, frame in enumerate(frames):
-            if fi == 0:
-                continue
+        # Test all but the first frame.
+        for fi, frame in enumerate(frames[1:], start=1):
             self.assertEqual(frame.id, fi + 1)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * fi)
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1) + constants.FRAME_OVERLAP)
@@ -221,7 +219,7 @@ class FrameGeneratorTest(unittest.TestCase):
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
         self.assertEqual(len(frames), constants.NUM_FRAMES_PER_SLICE - 1)
         for fi, frame in enumerate(frames):
-            self.assertEqual(frame.id, fi + 1)
+            self.assertEqual(frame.id, fi + 2)
             self.assertEqual(frame.sensing_start, ANX1 + constants.FRAME_GRID_SPACING * (fi + 1))
             self.assertEqual(frame.sensing_stop, ANX1 + constants.FRAME_GRID_SPACING * (fi + 2) + constants.FRAME_OVERLAP)
             self.assertEqual(frame.status, 'NOMINAL')

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -131,6 +131,31 @@ class FrameGeneratorTest(unittest.TestCase):
     gen = Level1PreProcessor(_Logger(), None, STANDARD_CONFIG, STANDARD_CONFIG)
     gen.read_scenario_parameters()
 
+    def test_frame_id(self) -> None:
+        '''Check whether frame IDs are set correctly.'''
+        # Entire slice that should create only nominal frames.
+        frames = self.gen._generate_frames(ANX1, ANX1, ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP, 1)
+        for fi, frame in enumerate(frames):
+            self.assertEqual(frame.id, fi + 1)
+
+        # Partial frames at start and end.
+        frames = self.gen._generate_frames(ANX1, ANX1 + datetime.timedelta(seconds=1),
+                                           ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP - datetime.timedelta(seconds=1), 1)
+        for fi, frame in enumerate(frames):
+            self.assertEqual(frame.id, fi + 1)
+
+        # Merged frames at start and end.
+        frames = self.gen._generate_frames(ANX1, ANX1 - datetime.timedelta(seconds=1),
+                                           ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP + datetime.timedelta(seconds=1), 1)
+        for fi, frame in enumerate(frames):
+            self.assertEqual(frame.id, fi + 1)
+
+        # Missing frames at start and end.
+        frames = self.gen._generate_frames(ANX1, ANX1 + constants.FRAME_GRID_SPACING,
+                                           ANX1 + constants.SLICE_GRID_SPACING + constants.FRAME_OVERLAP - constants.FRAME_GRID_SPACING, 1)
+        for fi, frame in enumerate(frames, start=1):  # First frame skipped, so start count at 1.
+            self.assertEqual(frame.id, fi + 1)
+
     def test_entire_slice(self) -> None:
         '''Try to create frames from an entire slice including overlaps on either side.'''
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START,


### PR DESCRIPTION
The previous implementation of the frame generator disregarded any data outside of the theoretical slice bounds. In reality, slices exceed their theoretical bounds due to the start/end overlap with other slices, as well as possible merging with neighbouring slices that are too short. This new implementation creates frames from the entire given time range, only using the theoretical slice bounds to determine the frame IDs.