### PR TITLE
34 datatakeid parameter not included in the mph of rawspid pc products

### DIFF
--- a/examples/procsim_config.json
+++ b/examples/procsim_config.json
@@ -130,6 +130,7 @@
       ],
       "zip_output": true,   // Default true, set false for diagnostics only
       "keep_zip": true,  // Set true for diagnostics only
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",
@@ -412,6 +413,7 @@
         "2021-02-01T00:25:33.745Z", // 1 second too late
         "2021-02-01T02:03:43.725Z"  // 1 second too early
       ],
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",
@@ -658,6 +660,7 @@
         "2021-02-01T00:25:33.745Z", // 1 second too late
         "2021-02-01T02:03:43.725Z"  // 1 second too early
       ],
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",

--- a/procsim/biomass/main_product_header.py
+++ b/procsim/biomass/main_product_header.py
@@ -449,9 +449,7 @@ class MainProductHeader:
                     et.SubElement(acquisition, bio + 'instrumentConfID').text = str(acq.instrument_config_id)
                 if level in ['l0', 'l1'] or self.product_type in ['AUX_ATT___', 'AUX_ORB___'] or \
                         self.product_type in product_types.RAWS_PRODUCT_TYPES:
-                    dataTakeID = et.SubElement(acquisition, bio + 'dataTakeID')
-                    if acq.data_take_id is not None:
-                        dataTakeID.text = str(acq.data_take_id)
+                    et.SubElement(acquisition, bio + 'dataTakeID').text = str(acq.data_take_id)
                 if level in ['l0', 'l1']:
                     et.SubElement(acquisition, bio + 'orbitDriftFlag').text = str(acq.orbit_drift_flag).lower()
                 if level in ['l0', 'l1', 'l2a']:

--- a/procsim/biomass/main_product_header.py
+++ b/procsim/biomass/main_product_header.py
@@ -73,7 +73,7 @@ def _time_from_iso_short(timestr: Optional[str]) -> Optional[datetime.datetime]:
 
 
 def _to_int(val: Optional[str]) -> Optional[int]:
-    return None if val is None else int(val)
+    return int(val) if val else None
 
 
 def _to_bool(val: Optional[str]) -> Optional[bool]:
@@ -447,8 +447,11 @@ class MainProductHeader:
                     et.SubElement(acquisition, bio + 'missionPhase').text = acq.mission_phase
                 if level in ['l0', 'l1']:
                     et.SubElement(acquisition, bio + 'instrumentConfID').text = str(acq.instrument_config_id)
-                if level in ['l0', 'l1'] or self.product_type in ['AUX_ATT___', 'AUX_ORB___']:
-                    et.SubElement(acquisition, bio + 'dataTakeID').text = str(acq.data_take_id)
+                if level in ['l0', 'l1'] or self.product_type in ['AUX_ATT___', 'AUX_ORB___'] or \
+                        self.product_type in product_types.RAWS_PRODUCT_TYPES:
+                    dataTakeID = et.SubElement(acquisition, bio + 'dataTakeID')
+                    if acq.data_take_id is not None:
+                        dataTakeID.text = str(acq.data_take_id)
                 if level in ['l0', 'l1']:
                     et.SubElement(acquisition, bio + 'orbitDriftFlag').text = str(acq.orbit_drift_flag).lower()
                 if level in ['l0', 'l1', 'l2a']:

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -7,7 +7,7 @@ from math import ceil
 import os
 import re
 import shutil
-from typing import Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 from xml.etree import ElementTree as et
 from procsim.biomass.constants import ORBITAL_PERIOD
 
@@ -304,6 +304,43 @@ class ProductGeneratorBase(IProductGenerator):
         slice_frame_start = previous_anx + (slice_frame_nr - 1) * spacing
         slice_frame_end = previous_anx + slice_frame_nr * spacing
         return slice_frame_start, slice_frame_end
+
+    def _get_data_takes_with_bounds(self) -> List[Tuple[Dict, datetime.datetime, datetime.datetime]]:
+        '''
+        Find data take(s) in the current sensing time bounds. Returns a list of
+        tuples  containing the start and end time of a data take, as well as the
+        data take itself. The start/end times are clamped within the sensing
+        time as set in the header (begin/end position).
+        '''
+        sensing_start = self._hdr.begin_position
+        sensing_stop = self._hdr.end_position
+        if sensing_start is None or sensing_stop is None:
+            raise ScenarioError('Sensing start and stop time are not set.')
+        data_takes = self._scenario_config.get('data_takes')
+        if not data_takes:
+            raise ScenarioError('Missing "data_takes" section in scenario')
+        if any([dt.get('start') is None or dt.get('stop') is None for dt in data_takes]):
+            raise ScenarioError('data_take in config should contain start/stop elements')
+        data_takes.sort(key=lambda dt: self._time_from_iso(dt['start']))
+
+        # Select the data takes that fall within the begin and end position.
+        data_takes = [dt for dt in data_takes if self._time_from_iso(dt['start']) <= sensing_stop and
+                      self._time_from_iso(dt['stop']) >= sensing_start]
+
+        # Warn that sensing start/end times fall outside of data takes, if necessary.
+        if data_takes and sensing_start < self._time_from_iso(data_takes[0]['start']):
+            self._logger.warning(f'Sensing start {sensing_start} outside of data take. Using data take start time.')
+        if data_takes and sensing_stop > self._time_from_iso(data_takes[-1]['stop']):
+            self._logger.warning(f'Sensing stop {sensing_stop} outside of data take. Using data take stop time.')
+
+        # Create resulting list of tuples.
+        data_takes_with_bounds: List[Tuple[Dict, datetime.datetime, datetime.datetime]] = []
+        for data_take in data_takes:
+            data_take_start = max(sensing_start, self._time_from_iso(data_take['start']))
+            data_take_stop = min(sensing_stop, self._time_from_iso(data_take['stop']))
+            data_takes_with_bounds.append((data_take, data_take_start, data_take_stop))
+
+        return data_takes_with_bounds
 
     def _read_config_param(self, config: dict, param_name: str, obj: object, hdr_field: str, ptype):
         '''

--- a/procsim/biomass/raw_product_generator.py
+++ b/procsim/biomass/raw_product_generator.py
@@ -204,9 +204,7 @@ class RAWSxxx_10(RawProductGeneratorBase):
 
         data_takes_with_bounds = self._get_data_takes_with_bounds()
         for data_take_config, data_take_start, data_take_stop in data_takes_with_bounds:
-            # Verify existence of mandatory data take variables.
-            if not data_take_config.get('data_take_id'):
-                raise ScenarioError('Missing data_take_id in data take configuration')
+            # If the data take ID does not exist, the data take getter should have failed.
             self._hdr.acquisitions[0].data_take_id = data_take_config['data_take_id']
             if self._enable_slicing:
                 self._generate_sliced_output(data_take_start, data_take_stop)

--- a/procsim/biomass/test/test_main_product_header.py
+++ b/procsim/biomass/test/test_main_product_header.py
@@ -245,6 +245,7 @@ class MphTest(unittest.TestCase):
                 'baseline': 10,
                 'acquisition_date': '2021-01-01T00:00:00.000Z',
                 'acquisition_station': 'unittest',
+                'data_take_id': '1234',
             }
             raw_gen = raw_generator_class(_Logger(), None, config, config)
 

--- a/procsim/biomass/test/test_main_product_header.py
+++ b/procsim/biomass/test/test_main_product_header.py
@@ -245,7 +245,7 @@ class MphTest(unittest.TestCase):
                 'baseline': 10,
                 'acquisition_date': '2021-01-01T00:00:00.000Z',
                 'acquisition_station': 'unittest',
-                'data_take_id': '1234',
+                'data_take_id': 1234,
             }
             raw_gen = raw_generator_class(_Logger(), None, config, config)
 

--- a/procsim/biomass/test/test_raw_product_generator.py
+++ b/procsim/biomass/test/test_raw_product_generator.py
@@ -71,7 +71,8 @@ class RAWSxxx_10Test(unittest.TestCase):
             'zip_output': False,
             'slice_overlap_start': 5.0,
             'slice_overlap_end': 7.0,
-            'slice_minimum_duration': 15.0
+            'slice_minimum_duration': 15.0,
+            'data_take_id': 1
         }
         self.anx1 = datetime.datetime(2021, 1, 31, 22, 47, 21, 765000, tzinfo=datetime.timezone.utc)
         self.anx2 = datetime.datetime(2021, 2, 1, 0, 25, 33, 745000, tzinfo=datetime.timezone.utc)

--- a/procsim/biomass/test/test_raw_product_generator.py
+++ b/procsim/biomass/test/test_raw_product_generator.py
@@ -242,8 +242,7 @@ class RAWSxxx_10Test(unittest.TestCase):
 
     def testMultipleDataTakes(self) -> None:
         '''
-        Test that multiple data takes appear in the MPH and that the
-        correct products are generated.
+        Test that multiple data create multiple products.
         '''
         # Get the start/stop times of the data takes.
         sensing_start = datetime.datetime(2021, 2, 1, 0, 24, 32, 0, tzinfo=datetime.timezone.utc)

--- a/test/biomass/procsim_config.json
+++ b/test/biomass/procsim_config.json
@@ -131,6 +131,7 @@
       "zip_output": true,   // Default is true, set false for diagnostics only
       "zip_extension": ".zip",
       "keep_zip": true,  // Default is false, set true for diagnostics only
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",
@@ -417,6 +418,7 @@
       ],
       "zip_output": true,
       "zip_extension": ".zip",
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",
@@ -666,6 +668,7 @@
       ],
       "zip_output": true,
       "zip_extension": ".zip",
+      "data_take_id": 1,  // Mandatory for RAWS products.
       "outputs": [
         {
           "type": "RAWS022_10",


### PR DESCRIPTION
This PR addresses a change in the specifications concerning RAWS products. These are now required to have the `bio:dataTakeID` parameter set in their MPH (issue #34). Data take information getting is generalised in preparation for support in generators other than L0 and RAWS.