### PR TITLE
41 issue during l1 processing simulation

### DIFF
--- a/procsim/biomass/level0_product_generator.py
+++ b/procsim/biomass/level0_product_generator.py
@@ -58,7 +58,8 @@ class Sx_RAW__0x(product_generator.ProductGeneratorBase):
 
     The generator adjusts the following metadata:
     - phenomenonTime (the acquisition begin/end times), modifed in case of merge/split.
-    - partialSlice, set if slice is partial (slice with DT start/end)
+    - isPartial, set if slice is partial (slice with DT start/end)
+    - isMerged, set if slice is merged (slice with DT start/end)
     - dataTakeID (copied from data_takes section in scenario)
     - swathIdentifier (copied from scenario, either root, output section or
       data_takes section)

--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -438,12 +438,16 @@ class Level1Stripmap(product_generator.ProductGeneratorBase):
             # Trim 'UTC=' off the start of the timestamp and convert to datetime.
             self._hdr.end_position = self._time_from_iso(frame_stop_time_node.text[4:])
 
-        frame_status_node = root.find('Data_Block/frame_Status')
+        frame_status_node = root.find('Data_Block/frame_status')
         if frame_status_node is not None and frame_status_node.text is not None:
             self._frame_status = frame_status_node.text
 
         if not self._hdr.acquisitions[0].slice_frame_nr or not self._hdr.begin_position or not self._hdr.end_position or not self._frame_status:
-            self._logger.warning(f'Could not parse frame information from {file_name}.')
+            self._logger.warning(f'Could not parse frame information from {file_name}. Read the following values:\n'
+                                 + f'  frame number: {self._hdr.acquisitions[0].slice_frame_nr},\n'
+                                 + f'  begin position: {self._hdr.begin_position},\n'
+                                 + f'  end position: {self._hdr.end_position},\n'
+                                 + f'  frame status: {self._frame_status}')
 
     def _generate_product(self):
         name_gen = self._create_name_generator(self._hdr)

--- a/procsim/biomass/level1_product_generator.py
+++ b/procsim/biomass/level1_product_generator.py
@@ -184,7 +184,8 @@ class Level1PreProcessor(product_generator.ProductGeneratorBase):
 
         if not self._enable_framing:
             self._hdr.acquisitions[0].slice_frame_nr = None
-            self._hdr.partial_l1_frame = False
+            self._hdr.is_partial = False
+            self._hdr.is_merged = False
             self._generate_product()
         else:
             self._generate_frame_products()
@@ -448,6 +449,12 @@ class Level1Stripmap(product_generator.ProductGeneratorBase):
                                  + f'  begin position: {self._hdr.begin_position},\n'
                                  + f'  end position: {self._hdr.end_position},\n'
                                  + f'  frame status: {self._frame_status}')
+
+        # Set header variables based on the frame status.
+        self._hdr.is_partial = self._frame_status == FrameStatus.PARTIAL
+        self._hdr.is_merged = self._frame_status == FrameStatus.MERGED
+        # Setting the frame status to incomplete (based on contingency) is currently not supported.
+        self._hdr.is_incomplete = False
 
     def _generate_product(self):
         name_gen = self._create_name_generator(self._hdr)

--- a/procsim/biomass/main_product_header.py
+++ b/procsim/biomass/main_product_header.py
@@ -188,17 +188,16 @@ class MainProductHeader:
         self.nr_l0_lines: Optional[str] = None           # 2 comma separated integers, being numOfLinesHPol,numOfLinesVPol
         self.nr_l0_lines_missing: Optional[str] = None   # 2 comma separated integers, being numOfLinesHPol,numOfLinesVPol
         self.nr_l0_lines_corrupt: Optional[str] = None   # 2 comma separated integers, being numOfLinesHPol,numOfLinesVPol
-        self.incomplete_l0_slice: Optional[bool] = None
-        self.partial_l0_slice: Optional[bool] = None
         self.l1_frames_in_l0: Optional[str] = None      # '0,1,2,4,5'
 
         # L1 only
-        self.incomplete_l1_frame: Optional[bool] = None
-        self.partial_l1_frame: Optional[bool] = None
         self.browse_ref_id: Optional[str] = 'Unknown'
         self.browse_image_filename: Optional[str] = ''
 
         # L0 and L1
+        self.is_incomplete: Optional[bool] = None
+        self.is_partial: Optional[bool] = None
+        self.is_merged: Optional[bool] = None
         acquisition = Acquisition()
         self.acquisitions = [acquisition]
         self.tai_utc_diff = 0
@@ -248,11 +247,10 @@ class MainProductHeader:
             self.nr_l0_lines == other.nr_l0_lines and \
             self.nr_l0_lines_missing == other.nr_l0_lines_missing and \
             self.nr_l0_lines_corrupt == other.nr_l0_lines_corrupt and \
-            self.incomplete_l0_slice == other.incomplete_l0_slice and \
-            self.partial_l0_slice == other.partial_l0_slice and \
             self.l1_frames_in_l0 == other.l1_frames_in_l0 and \
-            self.incomplete_l1_frame == other.incomplete_l1_frame and \
-            self.partial_l1_frame == other.partial_l1_frame and \
+            self.is_incomplete == other.is_incomplete and \
+            self.is_partial == other.is_partial and \
+            self.is_merged == other.is_merged and \
             self.browse_ref_id == other.browse_ref_id and \
             self.browse_image_filename == other.browse_image_filename and \
             self.tai_utc_diff == other.tai_utc_diff and \
@@ -572,13 +570,12 @@ class MainProductHeader:
             et.SubElement(earth_observation_meta_data, bio + 'numOfLines').text = self.nr_l0_lines
             et.SubElement(earth_observation_meta_data, bio + 'numOfMissingLines').text = self.nr_l0_lines_missing
             et.SubElement(earth_observation_meta_data, bio + 'numOfCorruptedLines').text = self.nr_l0_lines_corrupt
-            et.SubElement(earth_observation_meta_data, bio + 'incompleteSlice').text = str(self.incomplete_l0_slice).lower()
-            et.SubElement(earth_observation_meta_data, bio + 'partialSlice').text = str(self.partial_l0_slice).lower()
             et.SubElement(earth_observation_meta_data, bio + 'framesList').text = self.l1_frames_in_l0
 
-        if level in ['l1']:
-            et.SubElement(earth_observation_meta_data, bio + 'incompleteFrame').text = str(self.incomplete_l1_frame).lower()
-            et.SubElement(earth_observation_meta_data, bio + 'partialFrame').text = str(self.partial_l1_frame).lower()
+        if level in ['l0', 'l1']:
+            et.SubElement(earth_observation_meta_data, bio + 'isIncomplete').text = str(self.is_incomplete).lower()
+            et.SubElement(earth_observation_meta_data, bio + 'isPartial').text = str(self.is_partial).lower()
+            et.SubElement(earth_observation_meta_data, bio + 'isMerged').text = str(self.is_merged).lower()
 
         for doc in self.reference_documents:
             et.SubElement(earth_observation_meta_data, bio + 'refDoc').text = doc
@@ -869,13 +866,12 @@ class MainProductHeader:
         self.nr_l0_lines = earth_observation_meta_data.findtext(bio + 'numOfLines')
         self.nr_l0_lines_missing = earth_observation_meta_data.findtext(bio + 'numOfMissingLines')
         self.nr_l0_lines_corrupt = earth_observation_meta_data.findtext(bio + 'numOfCorruptedLines')
-        self.incomplete_l0_slice = _to_bool(earth_observation_meta_data.findtext(bio + 'incompleteSlice'))
-        self.partial_l0_slice = _to_bool(earth_observation_meta_data.findtext(bio + 'partialSlice'))
         self.l1_frames_in_l0 = earth_observation_meta_data.findtext(bio + 'framesList')
 
-        # Level 1
-        self.incomplete_l1_frame = _to_bool(earth_observation_meta_data.findtext(bio + 'incompleteFrame'))
-        self.partial_l1_frame = _to_bool(earth_observation_meta_data.findtext(bio + 'partialFrame'))
+        # Level 0/1
+        self.is_incomplete = _to_bool(earth_observation_meta_data.findtext(bio + 'isIncomplete'))
+        self.is_partial = _to_bool(earth_observation_meta_data.findtext(bio + 'isPartial'))
+        self.is_merged = _to_bool(earth_observation_meta_data.findtext(bio + 'isMerged'))
 
         self.reference_documents.clear()
         for doc in earth_observation_meta_data.findall(bio + 'refDoc'):

--- a/procsim/biomass/test/bio_s2_scs__1s_20230101t120000_20230101t120021_i_g03_m03_c03_t131_f155_01_acz976.xml
+++ b/procsim/biomass/test/bio_s2_scs__1s_20230101t120000_20230101t120021_i_g03_m03_c03_t131_f155_01_acz976.xml
@@ -307,8 +307,9 @@ gml:id="BIO_S2_SCS__1S_20230101T120000_20230101T120021_I_G03_M03_C03_T131_F155_0
                 </bio:ProcessingInformation>
             </eop:processing>
             <bio:TAI-UTC>37</bio:TAI-UTC>
-            <bio:incompleteFrame>false</bio:incompleteFrame>
-            <bio:partialFrame>false</bio:partialFrame>
+            <bio:isIncomplete>false</bio:isIncomplete>
+            <bio:isPartial>false</bio:isPartial>
+            <bio:isMerged>false</bio:isMerged>
             <bio:refDoc>BIOMASS L1 PRODUCT FORMAT SPECIFICATION</bio:refDoc>
             <bio:refDoc>BIOMASS L1 PRODUCT FORMAT DEFINITION</bio:refDoc>
         </bio:EarthObservationMetaData>

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -120,7 +120,7 @@ VFRA_DATA = '''<?xml version="1.0" ?>
         <frame_id>155</frame_id>
         <frame_start_time>UTC=2022-04-21T14:38:31.123456</frame_start_time>
         <frame_stop_time>UTC=2022-04-21T14:38:52.654321</frame_stop_time>
-        <frame_Status>NOMINAL</frame_Status>
+        <frame_status>NOMINAL</frame_status>
         <ops_angle_start unit="deg">178.838710</ops_angle_start>
         <ops_angle_stop unit="deg">180</ops_angle_stop>
     </Data_Block>

--- a/procsim/biomass/test/test_main_product_header.py
+++ b/procsim/biomass/test/test_main_product_header.py
@@ -133,8 +133,9 @@ def get_l1_test_mph():
     mph.center_points = '-7.492090 -63.27095'
 
     mph.tai_utc_diff = 37
-    mph.incomplete_l1_frame = False
-    mph.partial_l1_frame = False
+    mph.is_incomplete = False
+    mph.is_partial = False
+    mph.is_merged = False
 
     mph.products = [
         {'file_name': 'BIO_S2_SCS__1S_20230101T120000_20230101T120021_I_G03_M03_C03_T131_F155_01_ACZ976'},


### PR DESCRIPTION
This PR addresses an issue in L1 production, where L1 virtual frame files were not correctly parsed (#41).

The main issue was the naming of the `frame_Status` field, which is named as such in the current spec, but was amended to `frame_status` in communication with the Biomass team. procsim was still using the old spelling of the element and as such could not recognise input files.

Another issue was that, although virtual frames were parsed, the parsed information was discarded. This is now used to set the appropriate fields in the MPH.

Between the MPH spec 2.1 and 2.3, the fields indicating incomplete/partial/merged slice/frame status have changed. Whereas they used to be separate between slices and frames before, they are now unified, simply being called `isIncomplete`, `isPartial` and `isMerged`.