### PR TITLE
42 frames generated at slice edges

### DIFF
--- a/procsim/biomass/main_product_header.py
+++ b/procsim/biomass/main_product_header.py
@@ -73,7 +73,10 @@ def _time_from_iso_short(timestr: Optional[str]) -> Optional[datetime.datetime]:
 
 
 def _to_int(val: Optional[str]) -> Optional[int]:
-    return int(val) if val else None
+    try:
+        return int(val) if val else None
+    except ValueError:
+        return None
 
 
 def _to_bool(val: Optional[str]) -> Optional[bool]:

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -219,7 +219,7 @@ class FrameGeneratorTest(unittest.TestCase):
 
     def test_slightly_partial_slice_at_start(self) -> None:
         '''Create frames from a slice that is missing data in its starting overlap.'''
-        test_offset = datetime.timedelta(microseconds=1)
+        test_offset = datetime.timedelta(milliseconds=1)
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START + test_offset,
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
 
@@ -239,7 +239,7 @@ class FrameGeneratorTest(unittest.TestCase):
 
     def test_slightly_partial_slice_at_end(self) -> None:
         '''Create frames from a slice that is missing data in its end overlap.'''
-        test_offset = datetime.timedelta(microseconds=1)
+        test_offset = datetime.timedelta(milliseconds=1)
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START,
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END - test_offset, 1)
 
@@ -259,7 +259,7 @@ class FrameGeneratorTest(unittest.TestCase):
 
     def test_slightly_merged_slice_at_start(self) -> None:
         '''Create frames from a slice that has additional data at its start.'''
-        test_offset = datetime.timedelta(microseconds=1)
+        test_offset = datetime.timedelta(milliseconds=1)
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START - test_offset,
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END, 1)
 
@@ -279,7 +279,7 @@ class FrameGeneratorTest(unittest.TestCase):
 
     def test_slightly_merged_slice_at_end(self) -> None:
         '''Create frames from a slice that has additional data at its end overlap.'''
-        test_offset = datetime.timedelta(microseconds=1)
+        test_offset = datetime.timedelta(milliseconds=1)
         frames = self.gen._generate_frames(ANX1, ANX1 - constants.SLICE_OVERLAP_START,
                                            ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END + test_offset, 1)
 


### PR DESCRIPTION
This PR aims to resolve an issue in which adjacent slices may generate additional frames in their overlap, even if that's unnecessary.

1. procsim now checks whether an input product's sensing time boundary matches the start/end of a slice including overlap. It does this via simple equation (`==`), but only up to the precision that is provided by the input product's MPH, which is up to milliseconds.
2. If the boundary matches the start/end of a slice, it is considered to be an internal slice boundary: it is expected that other slices border the current one. Frames are only generated within their theoretical limits, and the slice overlap is disregarded.
3. If the boundary does not match the start/end of a slice, it is considered to be an external slice boundary: either it is partial or it is merged, but in any case there are most likely no slices adjacent to this boundary. Frames are generated right up to this boundary, regardless of whether it is within or beyond normal slice bounds.