### PR TITLE
43 no generator for product fp gn  l2 a in biomass plugin

### DIFF
--- a/procsim/biomass/level2_product_generator.py
+++ b/procsim/biomass/level2_product_generator.py
@@ -34,10 +34,10 @@ class Level2a(product_generator.ProductGeneratorBase):
 
     The l2a processor input is an interferometric stack, with up to 3/7 L1c
     (Sx_STA__1S) products for a given frame. Additionally aux products:
-    AUX_PP2_2A (processing parameters) and AUX_DEM (Copernicus DEM).
+    AUX_PP2_2A (processing parameters), AUX_DEM (Copernicus DEM) and AUX_LCM
+    (C3S Land Cover Map). The latter two are not supported.
     '''
-    PRODUCTS = ['AGB_GN_L2A', 'FD_COV_L2A', 'FH_COH_L2A',
-                'FP_VBG_L2A', 'FP_FD__L2A', 'FP_FH__L2A', 'FP_ACM_L2A']
+    PRODUCTS = ['FP_GN__L2A', 'FP_FD__L2A', 'FP_FH__L2A']
 
     def __init__(self, logger, job_config, scenario_config: dict, output_config: dict):
         super().__init__(logger, job_config, scenario_config, output_config)

--- a/procsim/biomass/product_types.py
+++ b/procsim/biomass/product_types.py
@@ -72,16 +72,9 @@ PRODUCT_TYPES: List[ProductType] = [
     ProductType('S3_STA__1M', 'l1', 'Stripmap L1 Coregistered stack – Monitoring product'),
     ProductType('RO_SCS__1S', 'l1', 'RX Only L1 Single look Complex Slant range – Standard product'),
 
-    # Old L2a types (to be removed in the future)
-    ProductType('AGB_GN_L2A', 'l2a', 'L2a Above Ground Biomass product: ground cancelled, calibrated and multilooked image'),
-    ProductType('FD_COV_L2A', 'l2a', 'L2a Forest Disturbance product: covariance of ground cancelled image'),
-    ProductType('FH_COH_L2A', 'l2a', 'L2a Forest Height product'),
-
-    # New L2a types
-    ProductType('FP_VBG_L2A', 'l2a', 'L2a Above Ground Biomass product: ground cancelled, calibrated and multilooked image'),
+    ProductType('FP_GN__L2A', 'l2a', 'L2a Ground Notched product: geocoded, ground cancelled, calibrated and multilooked image product'),
     ProductType('FP_FD__L2A', 'l2a', 'L2a Forest Disturbance product: covariance of ground cancelled image'),
     ProductType('FP_FH__L2A', 'l2a', 'L2a Forest Height product'),
-    ProductType('FP_ACM_L2A', 'l2a', 'L2a product'),
 
     ProductType('AUX_ATT___', 'aux', 'Attitude Product'),
     ProductType('AUX_CAL_AB', 'aux', 'Calibration Parameters for L2-Above Ground Biomass Processor Product'),

--- a/procsim/biomass/test/test_level2_product_generator.py
+++ b/procsim/biomass/test/test_level2_product_generator.py
@@ -1,0 +1,148 @@
+'''
+Copyright (C) 2022 S[&]T, The Netherlands.
+'''
+import datetime
+import os
+import re
+import shutil
+import tempfile
+import unittest
+
+from procsim.biomass import constants
+from procsim.biomass.level2_product_generator import Level2a
+
+TEST_DIR = tempfile.TemporaryDirectory()
+
+
+class _Logger:
+    def __init__(self):
+        self.count = 0
+
+    def debug(self, *args, **kwargs):
+        # print(*args, **kwargs)
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        print(*args, **kwargs)
+
+    def error(self, *args, **kwargs):
+        print(*args, **kwargs)
+
+
+DATETIME_INPUT_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+ANX = datetime.datetime(2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+TOMOGRAPHIC_CONFIG = {
+    'output_path': TEST_DIR.name,
+    'name': 'Level-2a SCS Stack product generation TOM',
+    'mission_phase': 'TOMOGRAPHIC',
+    'file_name': 'level2a_task1.sh',
+    'processor_name': 'l2a_to',
+    'processor_version': '01.01',
+    'task_name': 'Step1',
+    'task_version': '01.01',
+
+    'outputs': [
+        {
+            'type': 'FP_FH__L2A',
+            'metadata_source': '.*S._STA__1S.*'
+        },
+        {
+            'type': 'FP_GN__L2A',
+            'metadata_source': '.*S._STA__1S.*'
+        }
+    ]
+}
+
+INTERFEROMETRIC_CONFIG = {
+    'output_path': TEST_DIR.name,
+    'name': 'Level-2a SCS Stack product generation INT',
+    'mission_phase': 'INTERFEROMETRIC',
+    'file_name': 'level2a_task1.sh',
+    'processor_name': 'l2a_in',
+    'processor_version': '01.01',
+    'task_name': 'Step1',
+    'task_version': '01.01',
+
+    'outputs': [
+        {
+            'type': 'FP_FD__L2A',
+            'metadata_source': '.*S._STA__1S.*'
+        },
+        {
+            'type': 'FP_FH__L2A',
+            'metadata_source': '.*S._STA__1S.*'
+        },
+        {
+            'type': 'FP_GN__L2A',
+            'metadata_source': '.*S._STA__1S.*'
+        }
+    ]
+}
+
+
+class Level2AGeneratorTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        '''Clear temporary directory between tests.'''
+        # Only expect directory products in folder.
+        for dir in os.listdir(TEST_DIR.name):
+            shutil.rmtree(os.path.join(TEST_DIR.name, dir))
+        return super().tearDown()
+
+    def test_generate_tomographic_from_scenario(self) -> None:
+        '''
+        Check whether the L2a generator produces tomographic output under
+        nominal conditions, purely from a scenario.
+        '''
+        # Add necessary parameters to scenario. These are normally read from input products.
+        no_inputs_config = {
+            **TOMOGRAPHIC_CONFIG,
+            'baseline': 1,
+            'begin_position': (ANX - constants.SLICE_OVERLAP_START).strftime(DATETIME_INPUT_FORMAT),
+            'end_position': (ANX + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END).strftime(DATETIME_INPUT_FORMAT),
+        }
+        for output_config in no_inputs_config['outputs']:
+            self.assertTrue(output_config['type'] in Level2a.PRODUCTS)
+
+            gen = Level2a(_Logger(), None, no_inputs_config, output_config)
+            gen.read_scenario_parameters()
+            gen.generate_output()
+
+        # Tomographic L2a production should yield two output products of types FP_FH__L2A and FP_GN__L2A.
+        products = [os.path.join(TEST_DIR.name, f) for f in os.listdir(TEST_DIR.name)]
+        self.assertEqual(len(products), 2)
+        for output_pattern in [r'.*FP_FH__L2A.*', r'.*FP_GN__L2A.*']:
+            self.assertTrue(any(re.match(output_pattern, f) for f in products))
+
+    def test_generate_interferometric_from_scenario(self) -> None:
+        '''
+        Check whether the L2a generator produces interferometric output under
+        nominal conditions, purely from a scenario.
+        '''
+        # Add necessary parameters to scenario. These are normally read from input products.
+        no_inputs_config = {
+            **INTERFEROMETRIC_CONFIG,
+            'baseline': 1,
+            'begin_position': (ANX - constants.SLICE_OVERLAP_START).strftime(DATETIME_INPUT_FORMAT),
+            'end_position': (ANX + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END).strftime(DATETIME_INPUT_FORMAT),
+        }
+        for output_config in no_inputs_config['outputs']:
+            self.assertTrue(output_config['type'] in Level2a.PRODUCTS)
+
+            gen = Level2a(_Logger(), None, no_inputs_config, output_config)
+            gen.read_scenario_parameters()
+            gen.generate_output()
+
+        # Tomographic L2a production should yield three output products of types FP_FH__L2A, FP_FD__L2A and FP_GN__L2A.
+        products = [os.path.join(TEST_DIR.name, f) for f in os.listdir(TEST_DIR.name)]
+        self.assertEqual(len(products), 3)
+        for output_pattern in [r'.*FP_FH__L2A.*', r'.*FP_FD__L2A.*', r'.*FP_GN__L2A.*']:
+            self.assertTrue(any(re.match(output_pattern, f) for f in products))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/biomass/procsim_config.json
+++ b/test/biomass/procsim_config.json
@@ -919,7 +919,7 @@
     {
       "name": "Level-2a SCS Stack product generation TOM",
       "file_name": "level2a_task1.sh",
-      "processor_name": "l2a",
+      "processor_name": "l2a_to",
       "processor_version": "01.01",
       "task_name": "Step1",
       "task_version": "01.01",
@@ -930,7 +930,32 @@
           "metadata_source": ".*S._STA__1S.*"
         },
         {
-          "type": "FP_VBG_L2A",
+          "type": "FP_GN__L2A",
+          "metadata_source": ".*S._STA__1S.*"
+        }
+      ]
+    },
+
+    // Level2a, (interferometric phase)
+    {
+      "name": "Level-2a SCS Stack product generation INT",
+      "file_name": "level2a_task1.sh",
+      "processor_name": "l2a_in",
+      "processor_version": "01.01",
+      "task_name": "Step1",
+      "task_version": "01.01",
+
+      "outputs": [
+        {
+          "type": "FP_FD__L2A",
+          "metadata_source": ".*S._STA__1S.*"
+        },
+        {
+          "type": "FP_FH__L2A",
+          "metadata_source": ".*S._STA__1S.*"
+        },
+        {
+          "type": "FP_GN__L2A",
           "metadata_source": ".*S._STA__1S.*"
         }
       ]

--- a/test/biomass/procsim_config_generate_all.json
+++ b/test/biomass/procsim_config_generate_all.json
@@ -79,8 +79,7 @@
               {"type": "S1_STA__1S"},{"type": "S2_STA__1S"},{"type": "S3_STA__1S"},{"type": "S1_STA__1M"},{"type": "S2_STA__1M"},
               {"type": "S3_STA__1M"},
 
-              {"type": "AGB_GN_L2A"},{"type": "FD_COV_L2A"},{"type": "FH_COH_L2A"},{"type": "FP_VBG_L2A"},{"type": "FP_FD__L2A"},{"type": "FP_FH__L2A"},
-              {"type": "FP_ACM_L2A"}
+              {"type": "FP_GN__L2A"},{"type": "FP_FD__L2A"},{"type": "FP_FH__L2A"}
             ]
         }
     ]

--- a/test/biomass/pvml_config.xml
+++ b/test/biomass/pvml_config.xml
@@ -165,29 +165,15 @@
       <matchExpression><![CDATA[.*S[x123]_STA__1M.*]]></matchExpression>
     </productType>
 
-    <!-- Level 2a, OLD -->
-    <productType name="FH_COH_L2A">
-      <matchExpression><![CDATA[.*FH_COH_L2A.*]]></matchExpression>
-    </productType>
-    <productType name="AGB_GN_L2A">
-      <matchExpression><![CDATA[.*AGB_GN_L2A.*]]></matchExpression>
-    </productType>
-    <productType name="FD_COV_L2A">
-      <matchExpression><![CDATA[.*FD_COV_L2A.*]]></matchExpression>
-    </productType>
-
-    <!-- Level 2a, NEW -->
-    <productType name="FP_VBG_L2A">
-      <matchExpression><![CDATA[.*FP_VBG_L2A.*]]></matchExpression>
-    </productType>
+    <!-- Level 2a -->
     <productType name="FP_FD__L2A">
       <matchExpression><![CDATA[.*FP_FD__L2A.*]]></matchExpression>
     </productType>
     <productType name="FP_FH__L2A">
       <matchExpression><![CDATA[.*FP_FH__L2A.*]]></matchExpression>
     </productType>
-    <productType name="FP_ACM_L2A">
-      <matchExpression><![CDATA[.*FP_ACM_L2A.*]]></matchExpression>
+    <productType name="FP_GN__L2A">
+      <matchExpression><![CDATA[.*FP_GN__L2A.*]]></matchExpression>
     </productType>
 
   </productTypes>

--- a/test/biomass/pvml_job_biomass_l2a_in.xml
+++ b/test/biomass/pvml_job_biomass_l2a_in.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<pvmlJob>
+  <jobOrderId>4000</jobOrderId>
+  <processorName>l2a_in</processorName>
+  <processorVersion>01.01</processorVersion>
+  <orderType>OFFL</orderType>
+  <processingParameters>
+    <parameter name="Orbit_Number">1234</parameter>
+  </processingParameters>
+  <tasks>
+    <task name="Step1">
+      <inputs>
+        <!-- Generated products -->
+        <input>
+          <file>workspace/3000/BIO_S1_STA__1S_20210201T002533_20210201T002554_T_G___M01_C01_T000_F001_00_??????</file>
+          <file>workspace/3000/BIO_S1_STA__1S_20210201T002533_20210201T002554_T_G___M01_C02_T000_F001_00_??????</file>
+          <file>workspace/3000/BIO_S1_STA__1S_20210201T002533_20210201T002554_T_G___M01_C03_T000_F001_00_??????</file>
+        </input>
+        <input>
+          <file>data/aux/BIO_AUX_PP2_2A_20210201T000000_20210201T013810_01_??????</file>
+        </input>
+      </inputs>
+      <exitCode>0</exitCode>
+    </task>
+  </tasks>
+</pvmlJob>

--- a/test/biomass/pvml_job_biomass_l2a_to.xml
+++ b/test/biomass/pvml_job_biomass_l2a_to.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <pvmlJob>
-  <jobOrderId>4000</jobOrderId>
-  <processorName>l2a</processorName>
+  <jobOrderId>4010</jobOrderId>
+  <processorName>l2a_to</processorName>
   <processorVersion>01.01</processorVersion>
   <orderType>OFFL</orderType>
   <processingParameters>

--- a/test/biomass/tasktables/TaskTable_Biomass_L2a_in.xml
+++ b/test/biomass/tasktables/TaskTable_Biomass_L2a_in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Task_Table>
-  <Processor_Name>l2a</Processor_Name>
+  <Processor_Name>l2a_in</Processor_Name>
   <Version>01.01</Version>
   <Test>No</Test>
   <Min_Disk_Space units="MB">1500</Min_Disk_Space>
@@ -30,10 +30,8 @@
           <Critical>true</Critical>
           <Criticality_Level>1</Criticality_Level>
           <File_Name>../../test/biomass/level2a_task1.sh</File_Name>
-          <List_of_Inputs count="2">
+          <List_of_Inputs count="4">
             <Input>
-              <!-- Input are multiple SCS__1S products (1..7)! 
-                   How to specify that? -->
               <Mode>ALWAYS</Mode>
               <Mandatory>Yes</Mandatory>
               <List_of_Alternatives count="1">
@@ -44,6 +42,23 @@
                   <T0 units="secs">0</T0>
                   <T1 units="secs">0</T1>
                   <File_Type>Sx_STA__1S</File_Type>
+                  <File_Name_Type>Physical</File_Name_Type>
+                  <Input_Source_Data>true</Input_Source_Data>
+                </Alternative>
+              </List_of_Alternatives>
+            </Input>
+            <Input>
+              <!-- This is also an output product. Only used from the second pass on so not mandatory. -->
+              <Mode>ALWAYS</Mode>
+              <Mandatory>No</Mandatory>
+              <List_of_Alternatives count="1">
+                <Alternative>
+                  <Order>1</Order>
+                  <Origin>DB</Origin>
+                  <Retrieval_Mode>LatestValCover</Retrieval_Mode>
+                  <T0 units="secs">0</T0>
+                  <T1 units="secs">0</T1>
+                  <File_Type>FP_FD__L2A</File_Type>
                   <File_Name_Type>Physical</File_Name_Type>
                   <Input_Source_Data>true</Input_Source_Data>
                 </Alternative>
@@ -65,10 +80,15 @@
                 </Alternative>
               </List_of_Alternatives>
             </Input>
+            <!-- Additional AUX_DEM and AUX_LCM inputs not supported. -->
           </List_of_Inputs>
-          <List_of_Outputs count="2">
-            <!-- Output are as many products as input SCS__1S products. 
-                 How to specify that? -->
+          <List_of_Outputs count="3">
+            <Output>
+              <Destination>DB</Destination>
+              <Mandatory>Yes</Mandatory>
+              <File_Type>FP_FD__L2A</File_Type>
+              <File_Name_Type>Directory</File_Name_Type>
+            </Output>
             <Output>
               <Destination>DB</Destination>
               <Mandatory>Yes</Mandatory>
@@ -78,7 +98,7 @@
             <Output>
               <Destination>DB</Destination>
               <Mandatory>Yes</Mandatory>
-              <File_Type>FP_VBG_L2A</File_Type>
+              <File_Type>FP_GN__L2A</File_Type>
               <File_Name_Type>Directory</File_Name_Type>
             </Output>
           </List_of_Outputs>

--- a/test/biomass/tasktables/TaskTable_Biomass_L2a_to.xml
+++ b/test/biomass/tasktables/TaskTable_Biomass_L2a_to.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Task_Table>
+  <Processor_Name>l2a_to</Processor_Name>
+  <Version>01.01</Version>
+  <Test>No</Test>
+  <Min_Disk_Space units="MB">1500</Min_Disk_Space>
+  <!--Assumes 120min product-->
+  <Max_Time units="sec">0</Max_Time>
+  <!--no time limit for execution-->
+  <Processing_Parameters count="1">
+    <Processing_Parameter mandatory="false">
+      <Param_Name>Orbit_Number</Param_Name>
+      <Param_Type>Number</Param_Type>
+      <Param_Description>Absolute orbit number of the acquisition</Param_Description>
+    </Processing_Parameter>
+  </Processing_Parameters>
+  <Private_Config>
+    <List_of_Cfg_Files count="0"/>
+  </Private_Config>
+  <List_of_Config_Spaces count="0"/>
+  <List_of_Pools count="1">
+    <Pool>
+      <Detached>false</Detached>
+      <Killing_Signal>15</Killing_Signal>
+      <List_of_Tasks count="1">
+        <!-- Step1, 'measurement mode' (=stripmap) -->
+        <Task>
+          <Name>Step1</Name>
+          <Version>01.01</Version>
+          <Critical>true</Critical>
+          <Criticality_Level>1</Criticality_Level>
+          <File_Name>../../test/biomass/level2a_task1.sh</File_Name>
+          <List_of_Inputs count="2">
+            <Input>
+              <Mode>ALWAYS</Mode>
+              <Mandatory>Yes</Mandatory>
+              <List_of_Alternatives count="1">
+                <Alternative>
+                  <Order>1</Order>
+                  <Origin>DB</Origin>
+                  <Retrieval_Mode>ValCover</Retrieval_Mode>
+                  <T0 units="secs">0</T0>
+                  <T1 units="secs">0</T1>
+                  <File_Type>Sx_STA__1S</File_Type>
+                  <File_Name_Type>Physical</File_Name_Type>
+                  <Input_Source_Data>true</Input_Source_Data>
+                </Alternative>
+              </List_of_Alternatives>
+            </Input>
+            <Input>
+              <Mode>ALWAYS</Mode>
+              <Mandatory>Yes</Mandatory>
+              <List_of_Alternatives count="1">
+                <Alternative>
+                  <Order>1</Order>
+                  <Origin>DB</Origin>
+                  <Retrieval_Mode>LatestValCover</Retrieval_Mode>
+                  <T0 units="secs">0</T0>
+                  <T1 units="secs">0</T1>
+                  <File_Type>AUX_PP2_2A</File_Type>
+                  <File_Name_Type>Physical</File_Name_Type>
+                  <Input_Source_Data>true</Input_Source_Data>
+                </Alternative>
+              </List_of_Alternatives>
+            </Input>
+            <!-- Additional AUX_DEM and AUX_LCM inputs not supported. -->
+          </List_of_Inputs>
+          <List_of_Outputs count="2">
+            <Output>
+              <Destination>DB</Destination>
+              <Mandatory>Yes</Mandatory>
+              <File_Type>FP_FH__L2A</File_Type>
+              <File_Name_Type>Directory</File_Name_Type>
+            </Output>
+            <Output>
+              <Destination>DB</Destination>
+              <Mandatory>Yes</Mandatory>
+              <File_Type>FP_GN__L2A</File_Type>
+              <File_Name_Type>Directory</File_Name_Type>
+            </Output>
+          </List_of_Outputs>
+          <List_of_Breakpoints count="0"> </List_of_Breakpoints>
+        </Task>
+      </List_of_Tasks>
+    </Pool>
+  </List_of_Pools>
+</Task_Table>

--- a/test/biomass/test.sh
+++ b/test/biomass/test.sh
@@ -67,8 +67,11 @@ $PVML_CMD test/biomass/pvml_config.xml test/biomass/pvml_job_biomass_l1_stack.xm
 
 # Level 2 steps
 echo
-echo '  *** L2a'
-$PVML_CMD test/biomass/pvml_config.xml test/biomass/pvml_job_biomass_l2a.xml
+echo '  *** L2a interferometric'
+$PVML_CMD test/biomass/pvml_config.xml test/biomass/pvml_job_biomass_l2a_in.xml
+echo
+echo '  *** L2a tomographic'
+$PVML_CMD test/biomass/pvml_config.xml test/biomass/pvml_job_biomass_l2a_to.xml
 
 
 # --------------------------------


### PR DESCRIPTION
This PR addresses an issue related to updated Level2a production documentation. It uses the latest L2a product output types and distinguishes between interferometric and tomographic productions.