### PR TITLE
37 support for multiple data takes

### DIFF
--- a/procsim/biomass/aux_product_generator.py
+++ b/procsim/biomass/aux_product_generator.py
@@ -120,6 +120,17 @@ class Aux(product_generator.ProductGeneratorBase):
         # Setup MPH
         self._hdr.product_type = self._output_type
 
+        # AUX_ATT___ and AUX_ORB___ types require data take information.
+        if self._output_type in ['AUX_ATT___', 'AUX_ORB___']:
+            for data_take_config, data_take_start, data_take_stop in self._get_data_takes_with_bounds():
+                self.read_scenario_parameters(data_take_config)
+                self._hdr.set_phenomenon_times(data_take_start, data_take_stop)
+
+                self._generate_product()
+        else:
+            self._generate_product()
+
+    def _generate_product(self) -> None:
         start, stop = self._hdr.begin_position, self._hdr.end_position
         if self._hdr.validity_start is None:
             self._hdr.validity_start = start

--- a/procsim/biomass/aux_product_generator.py
+++ b/procsim/biomass/aux_product_generator.py
@@ -51,6 +51,20 @@ class Aux(product_generator.ProductGeneratorBase):
           ]
         },
         ...
+
+    For AUX_ATT___ and AUX_ORB___ products, an array "data_takes" with one or
+    more data take objects can be specified in the scenario. Each data take
+    object must contain at least the ID and start/stop times, and can contain
+    other metadata fields. For example:
+
+      "data_takes": [
+        {
+          "data_take_id": 15,
+          "start": "2021-02-01T00:24:32.000Z",
+          "stop": "2021-02-01T00:29:32.000Z",
+          "swath": "S1",
+          "operational_mode": "SM"  // example of an optional field
+        },
     '''
 
     PRODUCTS = [

--- a/procsim/biomass/level0_product_generator.py
+++ b/procsim/biomass/level0_product_generator.py
@@ -43,7 +43,7 @@ class Sx_RAW__0x(product_generator.ProductGeneratorBase):
     merged. The output is a single product, or multiple if there are data take
     transitions within the slice period.
 
-    An array "data_takes" with one or more data take objects must be specified
+    An array "data_takes" with one or more data take objects can be specified
     in the scenario. Each data take object must contain at least the ID and
     start/stop times, and can contain other metadata fields. For example:
 
@@ -264,6 +264,19 @@ class Sx_RAW__0M(product_generator.ProductGeneratorBase):
     - incompleteSlice, set to false
     - phenomenonTime (the acquisition begin/end times)
     - validTime
+
+    An array "data_takes" with one or more data take objects can be specified
+    in the scenario. Each data take object must contain at least the ID and
+    start/stop times, and can contain other metadata fields. For example:
+
+      "data_takes": [
+        {
+          "data_take_id": 15,
+          "start": "2021-02-01T00:24:32.000Z",
+          "stop": "2021-02-01T00:29:32.000Z",
+          "swath": "S1",
+          "operational_mode": "SM"  // example of an optional field
+        },
     '''
 
     PRODUCTS = ['S1_RAW__0M', 'S2_RAW__0M', 'S3_RAW__0M', 'Sx_RAW__0M',

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -400,12 +400,15 @@ class ProductGeneratorBase(IProductGenerator):
         self._hdr.begin_position = self._job_toi_start - datetime.timedelta(seconds=self._toi_start_offset)
         self._hdr.end_position = self._job_toi_stop + datetime.timedelta(seconds=self._toi_stop_offset)
 
-    def read_scenario_parameters(self):
+    def read_scenario_parameters(self, config: Optional[Dict] = None) -> None:
         '''
-        Parse metadata parameters from scenario_config (either 'global' or for this output).
+        Parse metadata parameters from a scenario configuration. If specified,
+        parse a specific config, otherwise parse both 'global' or and output-
+        specific configs.
         '''
+        configs_to_read = [config] if config else [self._scenario_config, self._output_config]
         gen_params, hdr_params, acq_params = self.get_params()
-        for config in self._scenario_config, self._output_config:
+        for config in configs_to_read:
             for param, hdr_field, type in hdr_params:
                 self._read_config_param(config, param, self._hdr, hdr_field, type)
             for param, acq_field, type in acq_params:

--- a/procsim/biomass/product_generator.py
+++ b/procsim/biomass/product_generator.py
@@ -325,32 +325,36 @@ class ProductGeneratorBase(IProductGenerator):
         data_takes = self._scenario_config.get('data_takes')
         if data_takes:
             # Create copies of general config and amend with data take config.
-            data_takes = [{**self._scenario_config, **dt} for dt in data_takes]
+            data_takes = [{**self._scenario_config, **dt, 'begin_position': dt.get('start'), 'end_position': dt.get('stop')} for dt in data_takes]
         else:
             # No explicit data takes found, use general config.
             self._logger.info('No data takes found, using general config.')
-            data_takes = [{**self._scenario_config, 'start': self._time_as_iso(sensing_start), 'stop': self._time_as_iso(sensing_stop)}]
+            data_takes = [{
+                **self._scenario_config,
+                'begin_position': self._time_as_iso(sensing_start),
+                'end_position': self._time_as_iso(sensing_stop)
+            }]
 
         # Check for mandatory parameters.
-        if any([dt.get('start') is None or dt.get('stop') is None or dt.get('data_take_id') is None for dt in data_takes]):
+        if any([dt.get('begin_position') is None or dt.get('end_position') is None or dt.get('data_take_id') is None for dt in data_takes]):
             raise ScenarioError('data_take in config should contain start/stop/data_take_id elements')
-        data_takes.sort(key=lambda dt: self._time_from_iso(dt['start']))
+        data_takes.sort(key=lambda dt: self._time_from_iso(dt['begin_position']))
 
         # Select the data takes that fall within the begin and end position.
-        data_takes = [dt for dt in data_takes if self._time_from_iso(dt['start']) <= sensing_stop
-                      and self._time_from_iso(dt['stop']) >= sensing_start]
+        data_takes = [dt for dt in data_takes if self._time_from_iso(dt['begin_position']) <= sensing_stop
+                      and self._time_from_iso(dt['end_position']) >= sensing_start]
 
         # Warn that sensing start/end times fall outside of data takes, if necessary.
-        if data_takes and sensing_start < self._time_from_iso(data_takes[0]['start']):
+        if data_takes and sensing_start < self._time_from_iso(data_takes[0]['begin_position']):
             self._logger.warning(f'Sensing start {sensing_start} outside of data take. Using data take start time.')
-        if data_takes and sensing_stop > self._time_from_iso(data_takes[-1]['stop']):
+        if data_takes and sensing_stop > self._time_from_iso(data_takes[-1]['end_position']):
             self._logger.warning(f'Sensing stop {sensing_stop} outside of data take. Using data take stop time.')
 
         # Create resulting list of tuples.
         data_takes_with_bounds: List[Tuple[Dict, datetime.datetime, datetime.datetime]] = []
         for data_take in data_takes:
-            data_take_start = max(sensing_start, self._time_from_iso(data_take['start']))
-            data_take_stop = min(sensing_stop, self._time_from_iso(data_take['stop']))
+            data_take_start = max(sensing_start, self._time_from_iso(data_take['begin_position']))
+            data_take_stop = min(sensing_stop, self._time_from_iso(data_take['end_position']))
             data_takes_with_bounds.append((data_take, data_take_start, data_take_stop))
 
         return data_takes_with_bounds

--- a/procsim/biomass/raw_product_generator.py
+++ b/procsim/biomass/raw_product_generator.py
@@ -161,6 +161,19 @@ class RAWSxxx_10(RawProductGeneratorBase):
     - phenomenonTime, acquisition begin/end times.
     - validTime, theoretical slice begin/end times (including overlap).
     - wrsLatitudeGrid, aka the slice_frame_nr.
+
+    An array "data_takes" with one or more data take objects can be specified
+    in the scenario. Each data take object must contain at least the ID and
+    start/stop times, and can contain other metadata fields. For example:
+
+      "data_takes": [
+        {
+          "data_take_id": 15,
+          "start": "2021-02-01T00:24:32.000Z",
+          "stop": "2021-02-01T00:29:32.000Z",
+          "swath": "S1",
+          "operational_mode": "SM"  // example of an optional field
+        },
     '''
 
     PRODUCTS = ['RAWS022_10', 'RAWS023_10', 'RAWS024_10', 'RAWS025_10',
@@ -204,8 +217,7 @@ class RAWSxxx_10(RawProductGeneratorBase):
 
         data_takes_with_bounds = self._get_data_takes_with_bounds()
         for data_take_config, data_take_start, data_take_stop in data_takes_with_bounds:
-            # If the data take ID does not exist, the data take getter should have failed.
-            self._hdr.acquisitions[0].data_take_id = data_take_config['data_take_id']
+            self.read_scenario_parameters(data_take_config)
             if self._enable_slicing:
                 self._generate_sliced_output(data_take_start, data_take_stop)
             else:

--- a/procsim/biomass/test/test_data_takes.py
+++ b/procsim/biomass/test/test_data_takes.py
@@ -1,0 +1,196 @@
+'''
+Copyright (C) 2022 S[&]T, The Netherlands.
+'''
+import datetime
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from procsim.biomass.aux_product_generator import Aux
+from procsim.biomass.level0_product_generator import AC_RAW__0A, Sx_RAW__0M, Sx_RAW__0x
+from procsim.biomass.level1_product_generator import Level1PreProcessor, Level1Stack, Level1Stripmap
+from procsim.biomass.product_generator import ProductGeneratorBase
+from procsim.biomass.raw_product_generator import RAWSxxx_10
+from procsim.core.exceptions import ScenarioError
+
+TEST_DIR = tempfile.TemporaryDirectory()
+
+
+class _Logger:
+    def __init__(self):
+        self.count = 0
+
+    def debug(self, *args, **kwargs):
+        # print(*args, **kwargs)
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        print(*args, **kwargs)
+
+
+class DataTakeTest(unittest.TestCase):
+
+    GENERATORS_TO_TEST = [
+        RAWSxxx_10,
+        Sx_RAW__0x, Sx_RAW__0M, AC_RAW__0A,
+        Level1PreProcessor, Level1Stripmap, Level1Stack,
+        Aux  # Only AUX_ATT and AUX_ORB.
+    ]
+
+    # This config should contain all mandatory common parameters for all generators to test.
+    STANDARD_CONFIG = {
+        'output_path': TEST_DIR.name,
+        'mission_phase': 'INTERFEROMETRIC',
+        'processor_name': 'test_proc',
+        'processor_version': '1',
+        'baseline': 0,
+        'acquisition_date': '2020-01-01T00:00:00.000',
+        'acquisition_station': 'SVB',
+        'downlink_time': '2020-01-01T00:00:00.000',
+        'anx': [
+            '2020-01-01T00:00:00.000'
+        ],
+        'source_L0S': 'test_L0S',
+        'source_L0M': 'test_L0M',
+        'source_AUX_ORB': 'test_AUX_ORB'
+    }
+
+    def tearDown(self) -> None:
+        # Remove all files from the test directory between tests.
+        for filename in os.listdir(TEST_DIR.name):
+            full_path = os.path.join(TEST_DIR.name, filename)
+            if os.path.isfile(full_path):
+                os.remove(full_path)
+            elif os.path.isdir(full_path):
+                shutil.rmtree(full_path)
+        return super().tearDown()
+
+    def _get_generators(self, config: Optional[Dict] = None) -> List[ProductGeneratorBase]:
+        '''
+        Generators need specific parameters set. Those are set here and the
+        generators are returned.
+        '''
+        config_to_use = config if config else self.STANDARD_CONFIG
+        generators: List[ProductGeneratorBase] = []
+        for generator_class in self.GENERATORS_TO_TEST:
+            gen_type = generator_class.PRODUCTS[0]
+            gen_config = {**config_to_use, 'type': gen_type}
+            generators.append(generator_class(_Logger, None, gen_config, gen_config))
+        return generators
+
+    def test_no_data_take_info(self):
+        '''
+        Check whether product generation fails if data take information is
+        omitted.
+        '''
+        for generator in self._get_generators():
+            generator.read_scenario_parameters()
+            with self.assertRaises(ScenarioError):
+                generator.generate_output()
+
+    def test_data_take_info_in_root(self) -> None:
+        '''
+        Data take information should be readable from root. Check whether this
+        is the case.
+        '''
+        test_scenario = {**self.STANDARD_CONFIG,
+                         'begin_position': '2020-01-01T00:00:00.000',
+                         'end_position': '2020-01-01T00:01:00.000',
+                         'data_take_id': 1}
+        for generator in self._get_generators(test_scenario):
+            generator.read_scenario_parameters()
+            self.assertEqual(generator._hdr.acquisitions[0].data_take_id, 1)
+            self.assertEqual(generator._hdr.begin_position, datetime.datetime(2020, 1, 1, 0, 0, 0).replace(tzinfo=datetime.timezone.utc))
+            self.assertEqual(generator._hdr.end_position, datetime.datetime(2020, 1, 1, 0, 1, 0).replace(tzinfo=datetime.timezone.utc))
+            generator.generate_output()
+
+            print(generator, len(os.listdir(TEST_DIR.name)))
+
+        # All generators generate one product, except for the L1 preprocessor, which generates three in the given sensing time.
+        self.assertEqual(len(os.listdir(TEST_DIR.name)), len(self.GENERATORS_TO_TEST) + 2)
+
+    def test_data_take_info_in_list(self) -> None:
+        '''Test data take info parsing from data_takes list.'''
+        test_scenario = {
+            **self.STANDARD_CONFIG,
+            'begin_position': '2020-01-01T00:00:00.000',
+            'end_position': '2020-01-01T00:01:00.000',
+            'data_takes': [
+                {
+                    'data_take_id': 1,
+                    'start': '2020-01-01T00:00:00.000',
+                    'stop': '2020-01-01T00:00:20.000',
+                    'swath': 'S1'
+                },
+                {
+                    'data_take_id': 2,
+                    'start': '2020-01-01T00:00:20.000',
+                    'stop': '2020-01-01T00:00:40.000',
+                    'swath': 'S2'
+                },
+                {
+                    'data_take_id': 3,
+                    'start': '2020-01-01T00:00:40.000',
+                    'stop': '2020-01-01T00:01:00.000',
+                    'swath': 'AC'
+                },
+            ]}
+
+        for generator in self._get_generators(test_scenario):
+            generator.read_scenario_parameters()
+            generator.generate_output()
+
+        # All generators generate one product in the given data takes.
+        self.assertEqual(len(list(Path(TEST_DIR.name).glob('*'))), len(self.GENERATORS_TO_TEST) * 3)
+
+    def test_general_info_in_data_takes(self) -> None:
+        '''
+        Test whether generally required information can be read from data takes.
+        '''
+        # Three parameters are required at the top level: processor_name, processor_version and anx.
+        test_scenario = {
+            'processor_name': self.STANDARD_CONFIG['processor_name'],
+            'processor_version': self.STANDARD_CONFIG['processor_version'],
+            'anx': self.STANDARD_CONFIG['anx'],
+            'begin_position': '2020-01-01T00:00:00.000',
+            'end_position': '2020-01-01T00:01:00.000',
+            'data_takes': [
+                {
+                    **self.STANDARD_CONFIG,
+                    'data_take_id': 1,
+                    'start': '2020-01-01T00:00:00.000',
+                    'stop': '2020-01-01T00:00:20.000',
+                    'swath': 'S1'
+                },
+                {
+                    **self.STANDARD_CONFIG,
+                    'data_take_id': 2,
+                    'start': '2020-01-01T00:00:20.000',
+                    'stop': '2020-01-01T00:00:40.000',
+                    'swath': 'S2'
+                },
+                {
+                    **self.STANDARD_CONFIG,
+                    'data_take_id': 3,
+                    'start': '2020-01-01T00:00:40.000',
+                    'stop': '2020-01-01T00:01:00.000',
+                    'swath': 'AC'
+                },
+            ]}
+
+        for generator in self._get_generators(test_scenario):
+            generator.read_scenario_parameters()
+            generator.generate_output()
+
+        # All generators generate one product in the given data takes.
+        self.assertEqual(len(os.listdir(TEST_DIR.name)), len(self.GENERATORS_TO_TEST) * 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/procsim/biomass/test/test_level1_product_generator.py
+++ b/procsim/biomass/test/test_level1_product_generator.py
@@ -61,6 +61,7 @@ STANDARD_CONFIG = {
     'begin_position': (ANX1 - constants.SLICE_OVERLAP_START).strftime(DATETIME_INPUT_FORMAT),
     'end_position': (ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END).strftime(DATETIME_INPUT_FORMAT),
     'slice_frame_nr': 1,
+    'data_take_id': 1,
 }
 
 # From the GitHub repo, issue 35.
@@ -84,7 +85,8 @@ ANX_CONFIG = {
         '2017-02-25T09:54:51.827516Z',
         '2017-02-25T11:33:02.809016Z',
         '2017-02-25T13:11:13.790517Z'
-    ]
+    ],
+    'data_take_id': 1,
 }
 
 
@@ -582,8 +584,8 @@ class VirtualFrameProductTest(unittest.TestCase):
         gen.read_scenario_parameters()
 
         # Manually set sensing time to different times.
-        start_sensing_time = ANX1 + datetime.timedelta(seconds=1)
-        end_sensing_time = ANX1 + constants.SLICE_GRID_SPACING - datetime.timedelta(seconds=1)
+        start_sensing_time = ANX1
+        end_sensing_time = ANX1 + constants.SLICE_GRID_SPACING
         gen._hdr.validity_start = ANX1 - constants.SLICE_OVERLAP_START
         gen._hdr.validity_stop = ANX1 + constants.SLICE_GRID_SPACING + constants.SLICE_OVERLAP_END
         gen._hdr.begin_position = start_sensing_time


### PR DESCRIPTION
This PR generalises data take config reading and applies it to the products for which the dataTakeId MPH parameter is mandatory.